### PR TITLE
migrating to gatsby v2 webpack config api

### DIFF
--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -1,10 +1,15 @@
-exports.modifyWebpackConfig = ({ config }, options) => {
-  config.loader(`sass-resources`, {
-    test: /\.s[ac]ss$/,
-    loaders: ['sass-resources']
-  })
-  config.merge({
-    sassResources: options.resources
-  })
-  return config
-}
+exports.onCreateWebpackConfig = ({ actions }, options) => {
+  actions.setWebpackConfig({
+    module: {
+      rules: [
+        {
+          test: /\.s[ac]ss$/,
+          loader: "sass-resources-loader",
+          options: {
+            resources: options.resources
+          }
+        }
+      ]
+    }
+  });
+};


### PR DESCRIPTION
Migrating to Gatsby v2 new api

https://www.gatsbyjs.org/docs/migrating-from-v1-to-v2/#change-modifywebpackconfig-to-oncreatewebpackconfig