### PR TITLE
chore: allow for Gatsby v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "cross-env": "^5.0.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0"
   },
   "readme": "README.md",
   "keywords": [


### PR DESCRIPTION
For plugins that work just fine on v3, Gatsby [recommends](https://www.gatsbyjs.com/docs/reference/release-notes/migrating-from-v2-to-v3/#for-plugin-maintainers) just allowing it in peer deps

Thanks!