### PR TITLE
chore(project): support Gatsby v4, Webpack v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "webpack": "^4.0.0 || ^5.0.0",
+    "webpack": "^5.0.0",
     "sass-resources-loader": "^1.3.3"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "cross-env": "^5.0.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
+    "gatsby": "^4.0.0"
   },
   "readme": "README.md",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "MIT",
   "dependencies": {
     "@babel/runtime": "^7.0.0",
-    "webpack": "^4.0.0",
+    "webpack": "^4.0.0 || ^5.0.0",
     "sass-resources-loader": "^1.3.3"
   },
   "devDependencies": {
@@ -19,7 +19,7 @@
     "cross-env": "^5.0.5"
   },
   "peerDependencies": {
-    "gatsby": "^2.0.0 || ^3.0.0"
+    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
   },
   "readme": "README.md",
   "keywords": [


### PR DESCRIPTION
Closes #15 

This will need a publish to npm so consumers can take advantage of the updates.